### PR TITLE
A fix and two improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <section>
         <p><label for="txt_input">Intridici tixti</label></p>
         <p><textarea rows="4" cols="50" id="txt_input" name="txt_input"></textarea></p>
-        <p><button type="button" onclick="mimimi('txt_input','txt_output','i')">MIMIMI!!!</button></p>
+        <p><button type="button" onclick="mimimi('txt_input','txt_output')">¡MIMIMI!</button></p>
         <p><textarea rows="4" cols="50"  id="txt_output" name="txt_output"></textarea></p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -35,11 +35,9 @@
 <body>
     <section>
         <p><label for="txt_input">Intridici tixti</label></p>
-        <p><textarea rows="4" cols="50" id="txt_input" name="txt_input">
-        </textarea></p>
+        <p><textarea rows="4" cols="50" id="txt_input" name="txt_input"></textarea></p>
         <p><button type="button" onclick="mimimi('txt_input','txt_output','i')">MIMIMI!!!</button></p>
-        <p><textarea rows="4" cols="50"  id="txt_output" name="txt_output">
-        </textarea></p>
+        <p><textarea rows="4" cols="50"  id="txt_output" name="txt_output"></textarea></p>
     </section>
 
 	

--- a/js/mimimi.js
+++ b/js/mimimi.js
@@ -2,18 +2,23 @@ function isUpper(c){
     return c == c.toUpperCase();
 }
 
-function mimimi(input,output,c){
+function mimimi(input,output){
     toUpper = function(x){ 
-	return x.toUpperCase();
+        return x.toUpperCase();
     };
-    var ilimintis=['a','e','i','o','u','á','é','í','ó','ú','ä','ë','ï','ö','ü'];
-    ilimintis=ilimintis.concat(ilimintis.map(toUpper));
+    var ilimintis = [['a','e','o','u'], ['á','é','ó','ú'], ['ä','ë','ö','ü']];
+    var sistiticiinis = ['i','í','ï'];
+    for (var i = 0; i < ilimintis.length; i++) {
+        ilimintis[i] = ilimintis[i].concat(ilimintis[i].map(toUpper));
+    }
     var txt_inpit=document.getElementById(input);
     var txt_iitpit=document.getElementById(output);
     var txt_inpit_vilii=txt_inpit.value;
     for (var i=0;i<ilimintis.length;i++){
-        if (txt_inpit_vilii.indexOf(ilimintis[i])>-1){
-            txt_inpit_vilii= txt_inpit_vilii.replace(new RegExp("\\" + ilimintis[i], 'g'), (isUpper(ilimintis[i]) ? c.toUpperCase() : c));
+        for (var j = 0; j < ilimintis[i].length; j++) {
+            if (txt_inpit_vilii.indexOf(ilimintis[i][j])>-1){
+                txt_inpit_vilii= txt_inpit_vilii.replace(new RegExp("\\" + ilimintis[i][j], 'g'), (isUpper(ilimintis[i][j]) ? sistiticiinis[i].toUpperCase() : sistiticiinis[i]));
+            }
         }
     }
     txt_iitpit.value=txt_inpit_vilii;

--- a/js/mimimi.js
+++ b/js/mimimi.js
@@ -6,8 +6,8 @@ function mimimi(input,output){
     toUpper = function(x){ 
         return x.toUpperCase();
     };
-    var ilimintis = [['a','e','o','u'], ['á','é','ó','ú'], ['ä','ë','ö','ü']];
-    var sistiticiinis = ['i','í','ï'];
+    var ilimintis = [['ca','que','qui','co','cu'],['cá','qué','quí','có','cú'],['a','e','o','u'], ['á','é','ó','ú'], ['ä','ë','ö','ü']];
+    var sistiticiinis = ['ki','kí','i','í','ï'];
     for (var i = 0; i < ilimintis.length; i++) {
         ilimintis[i] = ilimintis[i].concat(ilimintis[i].map(toUpper));
     }
@@ -17,7 +17,7 @@ function mimimi(input,output){
     for (var i=0;i<ilimintis.length;i++){
         for (var j = 0; j < ilimintis[i].length; j++) {
             if (txt_inpit_vilii.indexOf(ilimintis[i][j])>-1){
-                txt_inpit_vilii= txt_inpit_vilii.replace(new RegExp("\\" + ilimintis[i][j], 'g'), (isUpper(ilimintis[i][j]) ? sistiticiinis[i].toUpperCase() : sistiticiinis[i]));
+                txt_inpit_vilii= txt_inpit_vilii.replace(new RegExp(ilimintis[i][j], 'g'), (isUpper(ilimintis[i][j]) ? sistiticiinis[i].toUpperCase() : sistiticiinis[i]));
             }
         }
     }


### PR DESCRIPTION
-   Fixes the several spaces that were written in the text field when you open the page.
-   Substitute according diacritics (`á` > `í`).
-   Tries to keep sounds as in the original (assuming spanish). For example, `casa` (which is read as `/kasa/` in Spanish) transforms to `kisi` instead of `cisi`, that would be read as `/θisi/`.

Still, this leaves the problem that `gui` (`/gi/`) transforms to `gii` (`/xii/`), but to solve that, the regex should be changed to discard every u in `gue` or `gui`. Maybe I'll do it some day... maybe next Hacktoberfest? XD